### PR TITLE
Configure Product CT display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,12 @@
     ],
     "require": {
         "composer/installers": "^1.2",
+        "drupal/addtoany": "^1.12",
         "drupal/config_installer": "^1.8",
         "drupal/core-composer-scaffold": "^8.8",
         "drupal/core-project-message": "^8.8",
         "drupal/core-recommended": "^8.8",
+        "drupal/easy_breadcrumb": "^1.12",
         "drush/drush": "^10.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc699d8bcdbe703f858f5fc886667289",
+    "content-hash": "3ebdef252f9ef6b21c70d0667735b617",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1551,6 +1551,57 @@
             "time": "2019-06-08T11:03:04+00:00"
         },
         {
+            "name": "drupal/addtoany",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/addtoany.git",
+                "reference": "8.x-1.12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/addtoany-8.x-1.12.zip",
+                "reference": "8.x-1.12",
+                "shasum": "f66b3cb0a95b500e4802e8ff9c29af04554327d8"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.12",
+                    "datestamp": "1554702781",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "AddToAny",
+                    "homepage": "https://www.drupal.org/user/2640913"
+                },
+                {
+                    "name": "micropat",
+                    "homepage": "https://www.drupal.org/user/260224"
+                }
+            ],
+            "description": "Share buttons by AddToAny, including the AddToAny universal sharing button, Facebook, Twitter, Google+, Pinterest, and over 100 more on the <a href=\"https://www.addtoany.com/\" target=\"_blank\">AddToAny</a> platform.",
+            "homepage": "https://www.drupal.org/project/addtoany",
+            "support": {
+                "source": "https://git.drupalcode.org/project/addtoany"
+            }
+        },
+        {
             "name": "drupal/config_installer",
             "version": "1.8.0",
             "source": {
@@ -1990,6 +2041,89 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core."
+        },
+        {
+            "name": "drupal/easy_breadcrumb",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/easy_breadcrumb.git",
+                "reference": "8.x-1.12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/easy_breadcrumb-8.x-1.12.zip",
+                "reference": "8.x-1.12",
+                "shasum": "1364f8d3e36b1847279eeabf14ed26c62afcd750"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.12",
+                    "datestamp": "1557509285",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Boggs",
+                    "homepage": "https://www.drupal.org/user/153069"
+                },
+                {
+                    "name": "RenatoG",
+                    "homepage": "https://www.drupal.org/user/3326031"
+                },
+                {
+                    "name": "banoodle",
+                    "homepage": "https://www.drupal.org/user/2375050"
+                },
+                {
+                    "name": "diamondsea",
+                    "homepage": "https://www.drupal.org/user/430714"
+                },
+                {
+                    "name": "hmartens",
+                    "homepage": "https://www.drupal.org/user/622826"
+                },
+                {
+                    "name": "jasonsavino",
+                    "homepage": "https://www.drupal.org/user/411241"
+                },
+                {
+                    "name": "loopduplicate",
+                    "homepage": "https://www.drupal.org/user/717290"
+                },
+                {
+                    "name": "sonemonu",
+                    "homepage": "https://www.drupal.org/user/1667988"
+                },
+                {
+                    "name": "tatarbj",
+                    "homepage": "https://www.drupal.org/user/649590"
+                },
+                {
+                    "name": "volkswagenchick",
+                    "homepage": "https://www.drupal.org/user/3332522"
+                }
+            ],
+            "description": "Adds configuration to the system breadcrumbs.",
+            "homepage": "https://www.drupal.org/project/easy_breadcrumb",
+            "support": {
+                "source": "https://git.drupalcode.org/project/easy_breadcrumb"
+            }
         },
         {
             "name": "drush/drush",

--- a/config/sync/addtoany.settings.yml
+++ b/config/sync/addtoany.settings.yml
@@ -1,0 +1,22 @@
+buttons_size: 32
+additional_html: "<a class=\"a2a_button_facebook\"></a>\r\n<a class=\"a2a_button_instagram\"></a>\r\n<a class=\"a2a_button_pinterest\"></a>\r\n"
+additional_css: ''
+additional_js: ''
+universal_button: default
+custom_universal_button: ''
+universal_button_placement: after
+no_3p: false
+entities:
+  media: 1
+  node: 1
+  comment: 1
+  block_content: 0
+  contact_message: 0
+  file: 0
+  path_alias: 0
+  shortcut: 0
+  taxonomy_term: 0
+  user: 0
+  menu_link_content: 0
+_core:
+  default_config_hash: 9YPlBuinIKLe5jVEf-aIhZvKFn77i18yD4CrNR0BbVQ

--- a/config/sync/block.block.bartik_account_menu.yml
+++ b/config/sync/block.block.bartik_account_menu.yml
@@ -13,7 +13,7 @@ _core:
 id: bartik_account_menu
 theme: bartik
 region: secondary_menu
-weight: 0
+weight: -7
 provider: null
 plugin: 'system_menu_block:account'
 settings:

--- a/config/sync/block.block.bartik_breadcrumbs.yml
+++ b/config/sync/block.block.bartik_breadcrumbs.yml
@@ -10,8 +10,8 @@ _core:
   default_config_hash: oXUb3JZR2WW5VOdw4HrhRicCsq51mCgLfRyvheG68ck
 id: bartik_breadcrumbs
 theme: bartik
-region: breadcrumb
-weight: 0
+region: content
+weight: -5
 provider: null
 plugin: system_breadcrumb_block
 settings:

--- a/config/sync/block.block.bartik_content.yml
+++ b/config/sync/block.block.bartik_content.yml
@@ -11,7 +11,7 @@ _core:
 id: bartik_content
 theme: bartik
 region: content
-weight: 0
+weight: -1
 provider: null
 plugin: system_main_block
 settings:

--- a/config/sync/block.block.bartik_help.yml
+++ b/config/sync/block.block.bartik_help.yml
@@ -11,7 +11,7 @@ _core:
 id: bartik_help
 theme: bartik
 region: content
-weight: -30
+weight: -3
 provider: null
 plugin: help_block
 settings:

--- a/config/sync/block.block.bartik_local_actions.yml
+++ b/config/sync/block.block.bartik_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: bartik_local_actions
 theme: bartik
 region: content
-weight: -20
+weight: -2
 provider: null
 plugin: local_actions_block
 settings:

--- a/config/sync/block.block.bartik_local_tasks.yml
+++ b/config/sync/block.block.bartik_local_tasks.yml
@@ -9,7 +9,7 @@ _core:
 id: bartik_local_tasks
 theme: bartik
 region: content
-weight: -40
+weight: -4
 provider: null
 plugin: local_tasks_block
 settings:

--- a/config/sync/block.block.bartik_page_title.yml
+++ b/config/sync/block.block.bartik_page_title.yml
@@ -9,7 +9,7 @@ _core:
 id: bartik_page_title
 theme: bartik
 region: content
-weight: -50
+weight: -6
 provider: null
 plugin: page_title_block
 settings:

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -26,18 +26,18 @@ mode: default
 content:
   comment:
     type: comment_default
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   field_description:
-    weight: 4
+    weight: 5
     settings:
       rows: 5
       placeholder: ''
@@ -53,13 +53,23 @@ content:
       preview_image_style: thumbnail
     third_party_settings: {  }
   field_ingredients:
-    weight: 3
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
     region: content
+  field_tags:
+    type: entity_reference_autocomplete
+    weight: 3
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_type_of_food:
     weight: 2
     settings: {  }
@@ -68,7 +78,7 @@ content:
     region: content
   path:
     type: path
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -76,21 +86,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 8
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 12
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 9
     region: content
     third_party_settings: {  }
   title:
@@ -103,7 +113,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 6
     region: content
     settings:
       match_operator: CONTAINS
@@ -113,4 +123,3 @@ content:
     third_party_settings: {  }
 hidden:
   body: true
-  field_tags: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -25,9 +25,14 @@ targetEntityType: node
 bundle: article
 mode: default
 content:
+  addtoany:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   comment:
     type: comment_default
-    weight: 5
+    weight: 7
     region: content
     label: above
     settings:
@@ -35,7 +40,7 @@ content:
       pager_id: 0
     third_party_settings: {  }
   field_description:
-    weight: 1
+    weight: 2
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -52,13 +57,21 @@ content:
     label: hidden
   field_ingredients:
     type: basic_string
-    weight: 2
+    weight: 1
     region: content
     label: above
     settings: {  }
     third_party_settings: {  }
-  field_type_of_food:
+  field_tags:
+    type: entity_reference_label
     weight: 3
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_type_of_food:
+    weight: 4
     label: above
     settings:
       link: true
@@ -66,10 +79,9 @@ content:
     type: entity_reference_label
     region: content
   links:
-    weight: 4
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   body: true
-  field_tags: true

--- a/config/sync/core.entity_view_display.node.article.rss.yml
+++ b/config/sync/core.entity_view_display.node.article.rss.yml
@@ -25,6 +25,7 @@ content:
     weight: 100
     region: content
 hidden:
+  addtoany: true
   body: true
   comment: true
   field_description: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -62,6 +62,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  addtoany: true
   comment: true
   field_description: true
   field_tags: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -15,6 +15,11 @@ targetEntityType: node
 bundle: page
 mode: default
 content:
+  addtoany:
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   body:
     label: hidden
     type: text_default

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -16,6 +16,11 @@ targetEntityType: node
 bundle: page
 mode: teaser
 content:
+  addtoany:
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   body:
     label: hidden
     type: text_summary_or_trimmed

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -1,4 +1,5 @@
 module:
+  addtoany: 0
   automated_cron: 0
   big_pipe: 0
   block: 0
@@ -13,6 +14,7 @@ module:
   datetime: 0
   dblog: 0
   dynamic_page_cache: 0
+  easy_breadcrumb: 0
   editor: 0
   field: 0
   field_ui: 0
@@ -21,6 +23,7 @@ module:
   help: 0
   history: 0
   image: 0
+  ingredient_validation: 0
   link: 0
   menu_ui: 0
   node: 0

--- a/config/sync/easy_breadcrumb.settings.yml
+++ b/config/sync/easy_breadcrumb.settings.yml
@@ -1,0 +1,21 @@
+applies_admin_routes: true
+include_home_segment: true
+home_segment_title: Home
+home_segment_keep: false
+include_title_segment: true
+language_path_prefix_as_segment: false
+use_menu_title_as_fallback: false
+use_page_title_as_menu_title_fallback: false
+remove_repeated_segments: true
+term_hierarchy: false
+absolute_paths: false
+hide_single_home_item: false
+title_from_page_when_available: true
+_core:
+  default_config_hash: mmRzotiiDIFi2Ozs3xKRCRENuR9Dpd6sXlXoaI8FNTo
+include_invalid_paths: false
+excluded_paths: ''
+replaced_titles: ''
+custom_paths: ''
+segments_separator: null
+title_segment_as_link: false

--- a/config/sync/field.field.node.article.field_ingredients.yml
+++ b/config/sync/field.field.node.article.field_ingredients.yml
@@ -10,7 +10,7 @@ field_name: field_ingredients
 entity_type: node
 bundle: article
 label: Ingredients
-description: ''
+description: "Please enter ingredients in the correct form (Amount Unit Ingredient) and one in a line.<br>\r\nFor example: <br>\r\n12 g of sugar <br>\r\n<span>100 g of flour<br>\r\n<span>1 spoon of honey <br>\r\n"
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.article.field_tags.yml
+++ b/config/sync/field.field.node.article.field_tags.yml
@@ -13,7 +13,7 @@ field_name: field_tags
 entity_type: node
 bundle: article
 label: Tags
-description: 'Enter a comma-separated list. For example: Amsterdam, Mexico City, "Cleveland, Ohio"'
+description: 'Enter a comma-separated list. For example: vegetarian, vegan, gluten free, pescatarians, paleo, BBQ & grilling'
 required: false
 translatable: true
 default_value: {  }
@@ -26,4 +26,5 @@ settings:
     sort:
       field: _none
     auto_create: true
+    auto_create_bundle: ''
 field_type: entity_reference

--- a/config/sync/field.storage.node.field_ingredients.yml
+++ b/config/sync/field.storage.node.field_ingredients.yml
@@ -12,7 +12,7 @@ settings:
   case_sensitive: false
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
Configure Product CT display according to wireframe.
Limit ingredients input field to one fiel and add help description.
Add AddToAny module and customise.
Add EasyBreadcrumbs and customise.