### PR TITLE
Issue/8070 > master

### DIFF
--- a/config/sync/system.action.user_add_role_action.product_uploader.yml
+++ b/config/sync/system.action.user_add_role_action.product_uploader.yml
@@ -1,0 +1,14 @@
+uuid: 6276934e-4001-42b1-a4cc-89737360db64
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.product_uploader
+  module:
+    - user
+id: user_add_role_action.product_uploader
+label: 'Add the Product uploader role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: product_uploader

--- a/config/sync/system.action.user_remove_role_action.product_uploader.yml
+++ b/config/sync/system.action.user_remove_role_action.product_uploader.yml
@@ -1,0 +1,14 @@
+uuid: c70be99e-21e4-474e-8e67-9d2798157c6f
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.product_uploader
+  module:
+    - user
+id: user_remove_role_action.product_uploader
+label: 'Remove the Product uploader role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: product_uploader

--- a/config/sync/user.role.product_uploader.yml
+++ b/config/sync/user.role.product_uploader.yml
@@ -1,0 +1,11 @@
+uuid: 91f02858-607c-4423-abec-11649836dd34
+langcode: en
+status: true
+dependencies: {  }
+id: product_uploader
+label: 'Product uploader'
+weight: 3
+is_admin: null
+permissions:
+  - 'create article content'
+  - 'edit own article content'

--- a/web/modules/custom/product_uploader/product_uploader.info.yml
+++ b/web/modules/custom/product_uploader/product_uploader.info.yml
@@ -1,0 +1,5 @@
+name: Product Uploader
+type: module
+description: Assign or remove product uploader role
+package: Custom
+core: 8.x

--- a/web/modules/custom/product_uploader/product_uploader.info.yml
+++ b/web/modules/custom/product_uploader/product_uploader.info.yml
@@ -3,3 +3,6 @@ type: module
 description: Assign or remove product uploader role
 package: Custom
 core: 8.x
+dependencies:
+  - drupal:node
+  - drupal:field

--- a/web/modules/custom/product_uploader/product_uploader.info.yml
+++ b/web/modules/custom/product_uploader/product_uploader.info.yml
@@ -2,7 +2,7 @@ name: Product Uploader
 type: module
 description: Assign or remove product uploader role
 package: Custom
-core: 8.x
+core_version_requirement: ^8.8
 dependencies:
   - drupal:node
   - drupal:field

--- a/web/modules/custom/product_uploader/product_uploader.module
+++ b/web/modules/custom/product_uploader/product_uploader.module
@@ -5,23 +5,19 @@
  * Contains hook for Product Uploader module.
  */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 use Drupal\Core\Entity\EntityInterface;
 
 /**
- * Implements hook_entity_presave().
+ * Implements hook_ENTITY_TYPE_presave().
  */
-function product_uploader_entity_presave(EntityInterface $entity) {
-  if ($entity->bundle() === 'user') {
-    $mail = $entity->get('mail')->value;
-    if (strpos($mail, '+productuploader')) {
-      $entity->addRole('product_uploader');
-    }
-    else {
-      if ($entity->hasRole('product_uploader')) {
-        $entity->removeRole('product_uploader');
-      }
-    }
+function product_uploader_user_presave(EntityInterface $entity): void {
+  $mail = $entity->get('mail')->value;
+  if (strpos($mail, '+productuploader')) {
+    $entity->addRole('product_uploader');
+  }
+  else {
+    $entity->removeRole('product_uploader');
   }
 }

--- a/web/modules/custom/product_uploader/product_uploader.module
+++ b/web/modules/custom/product_uploader/product_uploader.module
@@ -7,11 +7,21 @@
 
 declare(strict_types=1);
 
-use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
- * Implements hook_form_alter()
+ * Implements hook_entity_presave().
  */
-function product_uploader_form_alter(){
-  
+function product_uploader_entity_presave(EntityInterface $entity) {
+  if ($entity->bundle() === 'user') {
+    $mail = $entity->get('mail')->value;
+    if (strpos($mail, '+productuploader')) {
+      $entity->addRole('product_uploader');
+    }
+    else {
+      if ($entity->hasRole('product_uploader')) {
+        $entity->removeRole('product_uploader');
+      }
+    }
+  }
 }

--- a/web/modules/custom/product_uploader/product_uploader.module
+++ b/web/modules/custom/product_uploader/product_uploader.module
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Contains hook for Product Uploader module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\EntityTypeInterface;
+
+/**
+ * Implements hook_form_alter()
+ */
+function product_uploader_form_alter(){
+  
+}


### PR DESCRIPTION
Configure the product uploading flow:

- Create a “Product uploader“ Drupal role, only this role should be able to create Product contents.
- Add the “Product uploader” role to the user upon registration when the user’s email address contains a “+productuploader” fragment (e.g. johndoe+productuploaded@gmail.com ).
- If the user changes email address on the profile page then the role should be either added or removed depending on the email address.